### PR TITLE
Add a handful of keys

### DIFF
--- a/src/LanguageMaps/Data/fi.csv
+++ b/src/LanguageMaps/Data/fi.csv
@@ -39,7 +39,7 @@ usbcode,normal,shifted,altgr,altgrshifted,deadkeys,bottomleft,topleft,bottomrigh
 41,,,,,,,,,Esc,
 42,,,,,,,,,Backspace,
 43,,,,,,,,,Tab,
-44, ,,,,,,,,Space,
+44,␣,,,,,,,,Space,
 45,+,?,\,,,,,,,
 46,´,`,,,Normal shifted,,,,,
 47,å,Å,,,,,Å,,,

--- a/src/LanguageMaps/Data/uk.csv
+++ b/src/LanguageMaps/Data/uk.csv
@@ -39,7 +39,7 @@ usbcode,normal,shifted,altgr,altgrshifted,deadkeys,bottomleft,topleft,topright,b
 41,,,,,,,,,,Esc,
 42,,,,,,,,,,Backspace,
 43,,,,,,,,,,Tab,
-44, ,,,,,,,,,Space,
+44,␣,,,,,,,,,Space,
 45,-,_,,,,,,,,,
 46,=,+,,,,,,,,,
 47,[,{,,,,,,,,,

--- a/src/LanguageMaps/Data/us.csv
+++ b/src/LanguageMaps/Data/us.csv
@@ -39,7 +39,7 @@ usbcode,normal,shifted,altgr,altgrshifted,deadkeys,bottomleft,topleft,topright,b
 41,,,,,,,,,,Esc,
 42,,,,,,,,,,Backspace,
 43,,,,,,,,,,Tab,
-44, ,,,,,,,,,Space,
+44,␣,,,,,,,,,Space,
 45,-,_,,,,,,,,,
 46,=,+,,,,,,,,,
 47,[,{,,,,,,,,,

--- a/src/LanguageMaps/Data/us.csv
+++ b/src/LanguageMaps/Data/us.csv
@@ -44,6 +44,7 @@ usbcode,normal,shifted,altgr,altgrshifted,deadkeys,bottomleft,topleft,topright,b
 46,=,+,,,,,,,,,
 47,[,{,,,,,,,,,
 48,],},,,,,,,,,
+49,\,|,,,,,,,,,
 50,??,??,,,,,,,,,
 51,;,:,,,,,,,,,
 52,',”,,,,,,,,,

--- a/src/QMK/functions.ts
+++ b/src/QMK/functions.ts
@@ -291,6 +291,7 @@ const SFT_T = (kc: keycode) => _MT(LSFT(kc));
 const ALT_T = (kc: keycode) => _MT(LALT(kc));
 const ALGR_T = (kc: keycode) => _MT(RALT(kc));
 const GUI_T = (kc: keycode) => _MT(LGUI(kc));
+const RCTL_T = (kc: keycode) => _MT(RCTL(kc));
 const ALL_T = (kc: keycode) => _MT(HYPR(kc));
 const LCAG_T = (kc: keycode) => _MT(LCAG(kc));
 const MEH_T = (kc: keycode) => _MT(MEH(kc));
@@ -420,6 +421,9 @@ const functionExpansionAliases: { [k: string]: keyof typeof functionExpansions }
 
 const functionNameAliases = {
     S: LSFT,
+    LALT_T: ALT_T,
+    LCTL_T: CTL_T,
+    LGUI_T: GUI_T,
 };
 
 const functions = {
@@ -430,6 +434,7 @@ const functions = {
     SFT_T,
     ALT_T,
     ALGR_T,
+    RCTL_T,
     GUI_T,
     ALL_T,
     LCAG_T,


### PR DESCRIPTION
This PR adds a couple missing macros, support for the \ (KC_BACKSLASH) key on the US keyboard, and a spacebar symbol when KC_SPACEBAR is combined with a special key.

For spacebar, this is how `ALT_T(KC_SPACEBAR)` was rendered before:
![image](https://user-images.githubusercontent.com/1069318/89953784-0f369e00-dc30-11ea-9a60-729767ca630a.png)

And after:
![image](https://user-images.githubusercontent.com/1069318/89953808-1bbaf680-dc30-11ea-9cc5-80379d5d94cb.png)
